### PR TITLE
Export interface include paths in the library target [ESD-1246] [ESD-1247]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,10 @@ set(_INSTALL_DESTINATIONS
 ### Library
 ###
 add_library(yaml-cpp ${library_sources})
+target_include_directories(yaml-cpp INTERFACE 
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    )
+
 set_target_properties(yaml-cpp PROPERTIES
   COMPILE_FLAGS "${yaml_c_flags} ${yaml_cxx_flags}"
 )


### PR DESCRIPTION
Integrates with https://github.com/swift-nav/cmake/pull/2

Part of the work to do with how we find and include project dependencies.

This PR simply adds the library include paths to the cmake target which already exists. This allow superprojects to pick up the header files without pulling directories directly out of the submodule.