### PR TITLE
Fix warning preventing compilation with gcc 8.2.0

### DIFF
--- a/include/yaml-cpp/emitter.h
+++ b/include/yaml-cpp/emitter.h
@@ -165,10 +165,10 @@ inline Emitter& Emitter::WriteStreamable(T value) {
       special = true;
       stream << ".nan";
     } else if (std::numeric_limits<T>::has_infinity) {
-      if (value == std::numeric_limits<T>::infinity()) {
+      if (std::isinf(value) && value > 0) {
         special = true;
         stream << ".inf";
-      } else if (value == -std::numeric_limits<T>::infinity()) {
+      } else if (std::isinf(value) && value < 0) {
         special = true;
         stream << "-.inf";
       }

--- a/include/yaml-cpp/node/detail/impl.h
+++ b/include/yaml-cpp/node/detail/impl.h
@@ -115,6 +115,7 @@ inline node* node_data::get(const Key& key,
         return pNode;
       return NULL;
     case NodeType::Scalar:
+    default:
       throw BadSubscript(key);
   }
 
@@ -143,6 +144,7 @@ inline node& node_data::get(const Key& key, shared_memory_holder pMemory) {
       convert_to_map(pMemory);
       break;
     case NodeType::Scalar:
+    default:
       throw BadSubscript(key);
   }
 

--- a/include/yaml-cpp/node/detail/node_iterator.h
+++ b/include/yaml-cpp/node/detail/node_iterator.h
@@ -111,6 +111,8 @@ class node_iterator_base
         return m_seqIt == rhs.m_seqIt;
       case iterator_type::Map:
         return m_mapIt == rhs.m_mapIt;
+      default:
+        break;
     }
     return true;
   }
@@ -131,6 +133,8 @@ class node_iterator_base
         ++m_mapIt;
         m_mapIt = increment_until_defined(m_mapIt);
         break;
+      default:
+        break;
     }
     return *this;
   }
@@ -149,6 +153,8 @@ class node_iterator_base
         return value_type(**m_seqIt);
       case iterator_type::Map:
         return value_type(*m_mapIt->first, *m_mapIt->second);
+      default:
+        break;
     }
     return value_type();
   }


### PR DESCRIPTION
Fix warning preventing compilation with gcc 8.2.0 when -Werror is enabled (due to -Werror=switch-default and -Werror=float-equal)