### PR TITLE
Fix missing header for uint32_t

### DIFF
--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cinttypes>
 #include <iomanip>
 #include <sstream>
 


### PR DESCRIPTION
# Changes

With the latest libstd++ version, the code doesn't explicitly include the C standard integer types. This will fix it.